### PR TITLE
Add support for Ruby 3

### DIFF
--- a/katex.gemspec
+++ b/katex.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/glebm/katex-ruby'
   s.license = 'MIT'
 
-  s.required_ruby_version = '~> 2.3'
+  s.required_ruby_version = '>= 2.3'
 
   s.files = Dir['{exe,lib,vendor}/**/*'] + %w[LICENSE.txt README.md]
   s.bindir = 'exe'
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'execjs', '~> 2.7'
 
-  s.add_development_dependency 'bundler', '~> 2.0.1'
+  s.add_development_dependency 'bundler', '~> 2.0'
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rubocop', '>= 0.55.0'


### PR DESCRIPTION
Ruby 3 has been released at Christmas, but this gem doesn't support it yet. Or rather the gemspec doesn't, the code itself seems to be working fine. This PR updates the gemspec accordingly.