### PR TITLE
(Fail to) Fix Travis build failures

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 3.0
   Exclude:
     - 'tmp/**/*'
     - 'vendor/**/*'


### PR DESCRIPTION
Travis doesn't support Ruby 2.3 anymore. So, updating this to 3.0 will probably fix the issue.