### PR TITLE
Changed the url for update to work with ruby3 (also changed repo url)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,9 +20,9 @@ task :update, :version do |_task, args| # rubocop:disable Metrics/BlockLength
   FileUtils.mkdir_p(dl_path)
   archive_path = File.join(dl_path, 'katex.tar.gz')
   unless File.exist?(archive_path)
-    url = 'https://github.com/Khan/KaTeX/releases/download/' \
+    url = 'https://github.com/KaTeX/KaTeX/releases/download/' \
           "#{version}/katex.tar.gz"
-    IO.copy_stream(open(url), archive_path) # rubocop:disable Security/Open
+    IO.copy_stream(URI.open(url), archive_path) # rubocop:disable Security/Open
   end
   katex_path = File.join(File.dirname(archive_path), 'katex')
   unless File.directory?(katex_path)


### PR DESCRIPTION
I found that to get the rake task update to work with ruby 3.0 I had to use URI.open rather than merely open (changes in the API ... I think but am not sure this is backward compatible).  Also the correct url now seems to be https://github.com/KaTeX/KaTeX/ rather than https://github.com/Khan/KaTeX/

As an aside, I personally couldn't get the dependencies for rubocup v.81 to compile on apple silicon with ruby 3 so I just switched to the latest version to get my dependencies to resolve but I suspect that will break other things so didn't include it in this pull request.